### PR TITLE
Fixed issue of missing exception handling.

### DIFF
--- a/src/main/scala/com/ir/IndexSearch.scala
+++ b/src/main/scala/com/ir/IndexSearch.scala
@@ -107,7 +107,11 @@ object IndexSearch {
     //extract posting lists of query
     var doc_lists: List[Array[Int]] = List[Array[Int]]()
     for (i <- query.indices) {
-      doc_lists ::= inverted(query(i))
+
+      try {
+        doc_lists ::= inverted(query(i))
+      }
+      catch {case _: Throwable => println(s"(NOTE: No results for '${query(i)}', therefore excluded from search)"); None}
     }
     intersect(doc_lists)
   }


### PR DESCRIPTION
Not found queries will be excluded from search now, e.g:

query "Präsident Harambe" will result in the following

`> Please, type in the search terms and press Enter: Präsident Harambe
>> (NOTE: No results for 'Harambe', therefore excluded from search)
 >> 77 194 541 646 841 1123 1643 2480 3039 3572 3725 4599 4982 5065`